### PR TITLE
Add image deletion.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -92,7 +92,7 @@
 		},
 		{
 			"ImportPath": "github.com/thoas/gokvstores",
-			"Rev": "c9be15c374e706810be9f09770644507bb58a3fd"
+			"Rev": "ae1105ba099c89f31af38c658ab6e64f1fc50e62"
 		},
 		{
 			"ImportPath": "github.com/thoas/muxer",

--- a/application/application.go
+++ b/application/application.go
@@ -151,11 +151,11 @@ func (a *Application) InitRouter() *negroni.Negroni {
 		UploadHandler(res, req, a)
 	}))
 
-	router.Handle("/delete/{path:[\\w\\-/.]+}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	router.Handle("/{path:[\\w\\-/.]+}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		res := muxer.NewResponse(w)
 		mreq := muxer.NewRequest(req)
 		DeleteHandler(res, mreq, a)
-	}))
+	})).Methods("DELETE")
 
 	allowedOrigins, err := a.Jq.ArrayOfStrings("allowed_origins")
 	allowedMethods, err := a.Jq.ArrayOfStrings("allowed_methods")

--- a/application/application.go
+++ b/application/application.go
@@ -151,11 +151,13 @@ func (a *Application) InitRouter() *negroni.Negroni {
 		UploadHandler(res, req, a)
 	}))
 
-	router.Handle("/{path:[\\w\\-/.]+}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		res := muxer.NewResponse(w)
-		mreq := muxer.NewRequest(req)
-		DeleteHandler(res, mreq, a)
-	})).Methods("DELETE")
+	if a.EnableDelete {
+		router.Handle("/{path:[\\w\\-/.]+}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			res := muxer.NewResponse(w)
+			mreq := muxer.NewRequest(req)
+			DeleteHandler(res, mreq, a)
+		})).Methods("DELETE")
+	}
 
 	allowedOrigins, err := a.Jq.ArrayOfStrings("allowed_origins")
 	allowedMethods, err := a.Jq.ArrayOfStrings("allowed_methods")

--- a/application/application.go
+++ b/application/application.go
@@ -37,6 +37,7 @@ type Shard struct {
 
 type Application struct {
 	EnableUpload  bool
+	EnableDelete  bool
 	Prefix        string
 	SecretKey     string
 	KVStore       gokvstores.KVStore

--- a/application/handlers.go
+++ b/application/handlers.go
@@ -66,11 +66,6 @@ var UploadHandler = func(res muxer.Response, req *http.Request, app *Application
 }
 
 var DeleteHandler = func(res muxer.Response, req *muxer.Request, app *Application) {
-	if !app.EnableDelete {
-		res.Forbidden()
-		return
-	}
-
 	if app.SourceStorage == nil {
 		res.Abort(500, "Your application doesn't have a source storage")
 		return

--- a/application/handlers.go
+++ b/application/handlers.go
@@ -65,6 +65,44 @@ var UploadHandler = func(res muxer.Response, req *http.Request, app *Application
 	res.ResponseWriter.Write(content)
 }
 
+var DeleteHandler = func(res muxer.Response, req *muxer.Request, app *Application) {
+	if !app.EnableDelete {
+		res.Forbidden()
+		return
+	}
+
+	if app.SourceStorage == nil {
+		res.Abort(500, "Your application doesn't have a source storage")
+		return
+	}
+
+	filename := req.Params["path"]
+
+	// Delete the image from the source storage right away.
+	// Upcoming requests will be able to read stuff from cache, but never
+	// create new things after we've deleted the source image.
+	//
+	// Don't care about an error here. If it's not there, then whatever..
+	// Keep going...
+	app.Logger.Infof("Deleting source storage file: %s", filename)
+	_ = app.SourceStorage.Delete(filename)
+
+	// We can clean up the rest now. Again, don't care about errors.
+	// ImageCleanup always succeeds.
+	app.ImageCleanup(filename)
+
+	content, err := json.Marshal(map[string]string{
+		"filename": filename,
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	res.ContentType("application/json")
+	res.ResponseWriter.Write(content)
+}
+
 var GetHandler Handler = func(res muxer.Response, req *Request, app *Application) {
 	file, err := app.ImageFileFromRequest(req, false, false)
 

--- a/application/initializers.go
+++ b/application/initializers.go
@@ -93,6 +93,12 @@ var BasicInitializer Initializer = func(jq *jsonq.JsonQuery, app *Application) e
 		app.EnableUpload = enableUpload
 	}
 
+	enableDelete, err := jq.Bool("options", "enable_delete")
+
+	if err == nil {
+		app.EnableDelete = enableDelete
+	}
+
 	return nil
 }
 

--- a/dummy/kvstore.go
+++ b/dummy/kvstore.go
@@ -41,3 +41,15 @@ func (k *DummyKVStoreConnection) Exists(key string) bool {
 func (k *DummyKVStoreConnection) Set(key string, value interface{}) error {
 	return nil
 }
+
+func (k *DummyKVStoreConnection) Append(key string, value interface{}) error {
+	return nil
+}
+
+func (k *DummyKVStoreConnection) SetAdd(key string, value interface{}) error {
+	return nil
+}
+
+func (k *DummyKVStoreConnection) SetMembers(key string) []interface{} {
+	return nil
+}


### PR DESCRIPTION
So, how it works.

First, there is a new config parameter under "options". Which is named "enable_delete". Same way as it is done with uploads. One should keep in mind and probably I should add that to readme. That only the database built with this parameter can delete images successfully. I did it intentionally, so that you don't pay for deletion feature if you don't need it. In other words, children set will not be created if this option is not set to true.

Deletion is a GET request. I know you wanted a DELETE request. I guess we can change that. But since I don't know how to handle different types of requests in your muxer I've left it this way. Also The image URLs for displaying are: `/display/`. And it doesn't make sense to me sending DELETE requests on `/display/` URLs. Anyways. The handler is bound to the following path right now: `/delete/{path:[\\w\\-/.]+}` (delete plus same path argument as in display and others).

Deletion feature maintains a set of hash keys under special key: `<src-filepath>:children` as you've suggested. Each element in the set points to the same KVStore.

Deletion feature does the following:

1. Delete source file in the source storage.
2. Get all children set elements for the file we're deleting.
3. Remove that children set from KVStore.
4. For each children in the set:
5. Get that key from KVStore.
6. Remove the file in the destination storage.
6. Remove the key from KVStore.

It's hard to tell if concurrent deletion requests and display requests are allowed. But it seems so. The main sync point is the source file. When the source file is gone, new display requests cannot create new images and hence won't write anything to KVStore or destination storage.

I'm pretty sure that simulatenous deletion and upload request will break things.

There.. any comments?

P.S. Example log:

```
2015/09/03 14:35:52 Serving [::]:3001 with pid 17012
INFO[0013] Started GET /display/resize/100x140/test1.jpg
INFO[0013] started handling request                      method=GET remote=[::1]:53370 request=/display/resize/100x140/test1.jpg
INFO[0013] Key fd875c2d5e6cbca8a79467d76d1089af not found in kvstore
INFO[0013] completed handling request                    measure#web.latency=55361768 method=GET remote=[::1]:53370 request=/display/resize/100x140/test1.jpg status=200 text_status=OK took=55.361768ms
INFO[0013] Completed 200 OK in 55.527683ms
INFO[0013] Save thumbnail fd875c2d5e6cbca8a79467d76d1089af.jpg to storage
INFO[0013] Save key fd875c2d5e6cbca8a79467d76d1089af => fd875c2d5e6cbca8a79467d76d1089af.jpg to kvstore
INFO[0013] Put key into set test1.jpg:children => fd875c2d5e6cbca8a79467d76d1089af in kvstore
INFO[0016] Started GET /display/resize/100x130/test1.jpg
INFO[0016] started handling request                      method=GET remote=[::1]:53370 request=/display/resize/100x130/test1.jpg
INFO[0016] Key f065a9618010d1c632cade29036c4d0c not found in kvstore
INFO[0016] completed handling request                    measure#web.latency=43879245 method=GET remote=[::1]:53370 request=/display/resize/100x130/test1.jpg status=200 text_status=OK took=43.879245ms
INFO[0016] Completed 200 OK in 43.987467ms
INFO[0016] Save thumbnail f065a9618010d1c632cade29036c4d0c.jpg to storage
INFO[0016] Save key f065a9618010d1c632cade29036c4d0c => f065a9618010d1c632cade29036c4d0c.jpg to kvstore
INFO[0016] Put key into set test1.jpg:children => f065a9618010d1c632cade29036c4d0c in kvstore
INFO[0019] Started GET /display/resize/100x120/test1.jpg
INFO[0019] started handling request                      method=GET remote=[::1]:53370 request=/display/resize/100x120/test1.jpg
INFO[0019] Key ee95aee309647ddd6711d26faf61fcc6 not found in kvstore
INFO[0019] completed handling request                    measure#web.latency=44762160 method=GET remote=[::1]:53370 request=/display/resize/100x120/test1.jpg status=200 text_status=OK took=44.76216ms
INFO[0019] Completed 200 OK in 44.871535ms
INFO[0019] Save thumbnail ee95aee309647ddd6711d26faf61fcc6.jpg to storage
INFO[0019] Save key ee95aee309647ddd6711d26faf61fcc6 => ee95aee309647ddd6711d26faf61fcc6.jpg to kvstore
INFO[0019] Put key into set test1.jpg:children => ee95aee309647ddd6711d26faf61fcc6 in kvstore
INFO[0024] Started GET /display/resize/100x110/test1.jpg
INFO[0024] started handling request                      method=GET remote=[::1]:53370 request=/display/resize/100x110/test1.jpg
INFO[0024] Key 2bdf7a15b14705854ead475c0b0e4f88 not found in kvstore
INFO[0024] completed handling request                    measure#web.latency=49457115 method=GET remote=[::1]:53370 request=/display/resize/100x110/test1.jpg status=200 text_status=OK took=49.457115ms
INFO[0024] Completed 200 OK in 49.568047ms
INFO[0024] Save thumbnail 2bdf7a15b14705854ead475c0b0e4f88.jpg to storage
INFO[0024] Save key 2bdf7a15b14705854ead475c0b0e4f88 => 2bdf7a15b14705854ead475c0b0e4f88.jpg to kvstore
INFO[0024] Put key into set test1.jpg:children => 2bdf7a15b14705854ead475c0b0e4f88 in kvstore
INFO[0033] Started GET /delete/test1.jpg
INFO[0033] started handling request                      method=GET remote=[::1]:53370 request=/delete/test1.jpg
INFO[0033] Deleting source storage file: test1.jpg
INFO[0033] Deleting children set: test1.jpg:children
INFO[0033] Deleting child f065a9618010d1c632cade29036c4d0c.jpg and its KV store entry f065a9618010d1c632cade29036c4d0c
INFO[0033] Deleting child ee95aee309647ddd6711d26faf61fcc6.jpg and its KV store entry ee95aee309647ddd6711d26faf61fcc6
INFO[0033] Deleting child 2bdf7a15b14705854ead475c0b0e4f88.jpg and its KV store entry 2bdf7a15b14705854ead475c0b0e4f88
INFO[0033] Deleting child fd875c2d5e6cbca8a79467d76d1089af.jpg and its KV store entry fd875c2d5e6cbca8a79467d76d1089af
INFO[0033] completed handling request                    measure#web.latency=457966 method=GET remote=[::1]:53370 request=/delete/test1.jpg status=200 text_status=OK took=457.966µs
INFO[0033] Completed 200 OK in 552.788µs
```