### PR TITLE
Updated Readme to make /upload more clear

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -496,6 +496,8 @@ storage to your configuration file.
         "enable_upload": true
       }
     }
+    
+To work properly, the input field must be named "data"
 
 Test it with the excellent httpie_:
 


### PR DESCRIPTION
I added a single line that will reduce confusion when setting up input fields. While the fact that the input field must be named "data" was suggested by the httpie example, I added a sentence that makes it much more explicit and removes the possibility for confusion