### PR TITLE
Fix bad logic for setting quality option

### DIFF
--- a/application/initializers.go
+++ b/application/initializers.go
@@ -72,7 +72,7 @@ var BasicInitializer Initializer = func(jq *jsonq.JsonQuery, app *Application) e
 
 	q, err := jq.Int("options", "quality")
 
-	if err != nil {
+	if err == nil {
 		quality = q
 	}
 


### PR DESCRIPTION
The quality option would never be properly set previously since it would only get set if there was an error, in which case the `q` will be zero.