### PR TITLE
Docker image: alpine instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.5
 
 ADD bin/picfit /picfit
 ADD ssl/ /etc/ssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine
 
 ADD bin/picfit /picfit
 ADD ssl/ /etc/ssl


### PR DESCRIPTION
`FROM scratch` is currently limiting us as it doesn't have sh in it, and as such cannot RUN on derived docker images.

Use case: we're deploying picfit 0.4 on a kubernetes cluster. Picfit makes assumptions on what format the config file is by the file extension. Our picfit config has to live as json on a kubernetes secret, and even though these can be mounted as files, the resulting filenames cannot have dots, therefore picfit is unable to understand our config file. To try work around this, we're extending the official Docker image like so:

```Dockerfile
FROM thoas/picfit:0.4.0-RC2

RUN ln -s /etc/picfit/config /etc/picfit.json

CMD ["/picfit", "-c", "/etc/picfit.json"]
```

Which results on
```
Step 1/3 : FROM thoas/picfit:0.4.0-RC2
0.4.0-RC2: Pulling from thoas/picfit
cc354913722f: Pulling fs layer
b86cc21077a1: Pulling fs layer
b86cc21077a1: Verifying Checksum
b86cc21077a1: Download complete
cc354913722f: Verifying Checksum
cc354913722f: Download complete
cc354913722f: Pull complete
b86cc21077a1: Pull complete
Digest: sha256:9e00a5f326d4ba64ca36ab021d019255d1a5efbb2e82fe87315db47a578feac0
Status: Downloaded newer image for thoas/picfit:0.4.0-RC2
 ---> 70ab12006bbe
Step 2/3 : RUN ln -s /etc/picfit/config /etc/picfit.json
 ---> Running in f569e9589a6c
container_linux.go:247: starting container process caused "exec: \"/bin/sh\": stat /bin/sh: no such file or directory"
oci runtime error: container_linux.go:247: starting container process caused "exec: \"/bin/sh\": stat /bin/sh: no such file or directory"
```

Adding alpine adds about 4MB into the official image, but opens it up for extension rather nicely.