### PR TITLE
Use github.com/alicebob/miniredis to make tests pass.

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -50,3 +50,4 @@ import:
   - package: github.com/spf13/cast
   - package: github.com/spf13/pflag
   - package: github.com/spf13/jwalterweatherman
+  - package: github.com/alicebob/miniredis


### PR DESCRIPTION
TestStorageApplicationWithPath and TestStorageApplicationWithURL will now
spin up their own in-memory redis instance, and fill out the proper host &
port in the config snippet to communicate with this redis instance.