### PR TITLE
Implement h=0 or w=0 for thumbnail and fit ops.

### DIFF
--- a/engine/goimage.go
+++ b/engine/goimage.go
@@ -56,6 +56,14 @@ func imageSize(e image.Image) (int, int) {
 }
 
 func (e *GoImageEngine) Scale(img image.Image, dstWidth int, dstHeight int, upscale bool, trans Transformation) image.Image {
+	b := img.Bounds()
+	srcWidth, srcHeight := b.Dx(), b.Dy()
+	if dstWidth == 0 {
+		dstWidth = dstHeight * srcWidth / srcHeight
+	}
+	if dstHeight == 0 {
+		dstHeight = dstWidth * srcHeight / srcWidth
+	}
 	factor := scalingFactorImage(img, dstWidth, dstHeight)
 
 	if factor < 1 || upscale {


### PR DESCRIPTION
The usage section of the documentation says:

width - The desired width of the image, if 0 is provided the service will
calculate the ratio with height
height - The desired height of the image, if 0 is provided the service will
calculate the ratio with width

But picfit panics if you attempt this with any op other than resize.  This
change makes it work with other ops.