### PR TITLE
feat: allow mimetype handling using backends

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.11.2
+FROM golang:1.11.5
 
 ADD . /go/src/github.com/thoas/picfit
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM golang:1.11.2
+FROM golang:1.11.5
 
 ADD . /go/src/github.com/thoas/picfit
 

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -1,23 +1,23 @@
 package config
 
-type BackendsConfig struct {
-	Lilliput *BackendConfig `mapstructure:"lilliput"`
-	GoImage  *BackendConfig `mapstructure:"goimage"`
+type Backends struct {
+	Lilliput *Backend `mapstructure:"lilliput"`
+	GoImage  *Backend `mapstructure:"goimage"`
 }
 
-type BackendConfig struct {
+type Backend struct {
 	Mimetypes []string
 }
 
 // Config is the engine config
 type Config struct {
-	Backends        *BackendsConfig `mapstructure:"backends"`
-	DefaultFormat   string          `mapstructure:"default_format"`
-	Format          string          `mapstructure:"format"`
-	Quality         int             `mapstructure:"quality"`
-	MaxBufferSize   int             `mapstructure:"max_buffer_size"`
-	ImageBufferSize int             `mapstructure:"image_buffer_size"`
-	JpegQuality     int             `mapstructure:"jpeg_quality"`
-	PngCompression  int             `mapstructure:"png_compression"`
-	WebpQuality     int             `mapstructure:"webp_quality"`
+	Backends        *Backends `mapstructure:"backends"`
+	DefaultFormat   string    `mapstructure:"default_format"`
+	Format          string    `mapstructure:"format"`
+	Quality         int       `mapstructure:"quality"`
+	MaxBufferSize   int       `mapstructure:"max_buffer_size"`
+	ImageBufferSize int       `mapstructure:"image_buffer_size"`
+	JpegQuality     int       `mapstructure:"jpeg_quality"`
+	PngCompression  int       `mapstructure:"png_compression"`
+	WebpQuality     int       `mapstructure:"webp_quality"`
 }

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -1,14 +1,23 @@
 package config
 
+type BackendsConfig struct {
+	Lilliput *BackendConfig `mapstructure:"lilliput"`
+	GoImage  *BackendConfig `mapstructure:"goimage"`
+}
+
+type BackendConfig struct {
+	Mimetypes []string
+}
+
 // Config is the engine config
 type Config struct {
-	Backends        []string `mapstructure:"backends"`
-	DefaultFormat   string   `mapstructure:"default_format"`
-	Format          string   `mapstructure:"format"`
-	Quality         int      `mapstructure:"quality"`
-	MaxBufferSize   int      `mapstructure:"max_buffer_size"`
-	ImageBufferSize int      `mapstructure:"image_buffer_size"`
-	JpegQuality     int      `mapstructure:"jpeg_quality"`
-	PngCompression  int      `mapstructure:"png_compression"`
-	WebpQuality     int      `mapstructure:"webp_quality"`
+	Backends        *BackendsConfig `mapstructure:"backends"`
+	DefaultFormat   string          `mapstructure:"default_format"`
+	Format          string          `mapstructure:"format"`
+	Quality         int             `mapstructure:"quality"`
+	MaxBufferSize   int             `mapstructure:"max_buffer_size"`
+	ImageBufferSize int             `mapstructure:"image_buffer_size"`
+	JpegQuality     int             `mapstructure:"jpeg_quality"`
+	PngCompression  int             `mapstructure:"png_compression"`
+	WebpQuality     int             `mapstructure:"webp_quality"`
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -88,7 +88,7 @@ func (e Engine) Transform(output *image.ImageFile, operations []EngineOperation)
 		}
 
 		for j := range backends {
-			processed, err = operate(e.backends[j], output, operations[i].Operation, operations[i].Options)
+			processed, err = operate(backends[j], output, operations[i].Operation, operations[i].Options)
 			if err == nil {
 				output.Source = processed
 				break

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -14,27 +14,39 @@ type Engine struct {
 	Format         string
 	DefaultQuality int
 
-	backends []backend.Backend
+	backends  []backend.Backend
+	mimetypes map[string]backend.Backend
 }
-
-const (
-	goEngineType       = "go"
-	lilliputEngineType = "lilliput"
-)
 
 // New initializes an Engine
 func New(cfg config.Config) *Engine {
-	var b []backend.Backend
-	for i := range cfg.Backends {
-		if cfg.Backends[i] == lilliputEngineType {
-			b = append(b, backend.NewLilliput(cfg))
-		} else if cfg.Backends[i] == goEngineType {
-			b = append(b, &backend.GoImage{})
-		}
-	}
+	var (
+		b         []backend.Backend
+		mimetypes = map[string]backend.Backend{}
+	)
 
-	if len(b) == 0 {
+	if cfg.Backends == nil {
 		b = append(b, &backend.GoImage{})
+	} else {
+		if cfg.Backends.Lilliput != nil {
+			back := backend.NewLilliput(cfg)
+
+			b = append(b, back)
+
+			for _, mimetype := range cfg.Backends.Lilliput.Mimetypes {
+				mimetypes[mimetype] = back
+			}
+		}
+
+		if cfg.Backends.GoImage != nil {
+			back := &backend.GoImage{}
+
+			b = append(b, back)
+
+			for _, mimetype := range cfg.Backends.GoImage.Mimetypes {
+				mimetypes[mimetype] = back
+			}
+		}
 	}
 
 	quality := config.DefaultQuality
@@ -47,13 +59,14 @@ func New(cfg config.Config) *Engine {
 		Format:         cfg.Format,
 		DefaultQuality: quality,
 		backends:       b,
+		mimetypes:      mimetypes,
 	}
 }
 
 func (e Engine) String() string {
-	backendNames := make([]string, len(e.backends))
-	for i := range e.backends {
-		backendNames[i] = e.backends[i].String()
+	backendNames := []string{}
+	for _, backend := range e.backends {
+		backendNames = append(backendNames, backend.String())
 	}
 
 	return strings.Join(backendNames, " ")
@@ -65,8 +78,16 @@ func (e Engine) Transform(output *image.ImageFile, operations []EngineOperation)
 		processed []byte
 		source    = output.Source
 	)
+
 	for i := range operations {
-		for j := range e.backends {
+		backends := e.backends
+
+		back, ok := e.mimetypes[output.ContentType()]
+		if ok {
+			backends = []backend.Backend{back}
+		}
+
+		for j := range backends {
 			processed, err = operate(e.backends[j], output, operations[i].Operation, operations[i].Options)
 			if err == nil {
 				output.Source = processed


### PR DESCRIPTION
```json
  "engine": {
    "backends": {
      "lilliput": {
        "mimetypes": ["image/gif"]
      },
      "goimage": {
        "mimetypes": ["image/jpeg", "image/png", "image/bmp"]
      }
    }
  },
```