### PR TITLE
public methods and variables to be able to use picfit as library

### DIFF
--- a/parameters.go
+++ b/parameters.go
@@ -35,7 +35,7 @@ type Parameters struct {
 }
 
 // newParameters returns Parameters for engine.
-func (p *Processor) newParameters(input *image.ImageFile, qs map[string]interface{}) (*Parameters, error) {
+func (p *Processor) NewParameters(input *image.ImageFile, qs map[string]interface{}) (*Parameters, error) {
 	format, ok := qs["fmt"].(string)
 	filepath := input.Filepath
 
@@ -46,8 +46,8 @@ func (p *Processor) newParameters(input *image.ImageFile, qs map[string]interfac
 
 	}
 
-	if format == "" && p.engine.Format != "" {
-		format = p.engine.Format
+	if format == "" && p.Engine.Format != "" {
+		format = p.Engine.Format
 	}
 
 	if format == "" {
@@ -55,7 +55,7 @@ func (p *Processor) newParameters(input *image.ImageFile, qs map[string]interfac
 	}
 
 	if format == "" {
-		format = p.engine.DefaultFormat
+		format = p.Engine.DefaultFormat
 	}
 
 	if format != input.Format() {
@@ -170,7 +170,7 @@ func (p Processor) NewEngineOperationFromQuery(op string) (*engine.EngineOperati
 func (p Processor) newBackendOptionsFromParameters(operation engine.Operation, qs map[string]interface{}) (*backend.Options, error) {
 	var (
 		err     error
-		quality = p.engine.DefaultQuality
+		quality = p.Engine.DefaultQuality
 		upscale = defaultUpscale
 		height  = defaultHeight
 		width   = defaultWidth

--- a/picfit.go
+++ b/picfit.go
@@ -36,6 +36,6 @@ func NewProcessor(cfg *config.Config) (*Processor, error) {
 		SourceStorage:      sourceStorage,
 		DestinationStorage: destinationStorage,
 		store:              s,
-		engine:             e,
+		Engine:             e,
 	}, nil
 }

--- a/processor.go
+++ b/processor.go
@@ -28,7 +28,7 @@ type Processor struct {
 	SourceStorage      gostorages.Storage
 	DestinationStorage gostorages.Storage
 	store              store.Store
-	engine             *engine.Engine
+	Engine             *engine.Engine
 }
 
 // Upload uploads a file to its storage
@@ -310,12 +310,12 @@ func (p *Processor) processImage(c *gin.Context, storeKey string, async bool) (*
 		return nil, errors.Wrap(err, "unable to process image")
 	}
 
-	parameters, err := p.newParameters(file, qs)
+	parameters, err := p.NewParameters(file, qs)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to process image")
 	}
 
-	file, err = p.engine.Transform(parameters.Output, parameters.Operations)
+	file, err = p.Engine.Transform(parameters.Output, parameters.Operations)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to process image")
 	}


### PR DESCRIPTION
I'm using `picfit` as a library (same way as `django-sorl-thumbnail`) to generate thumbnails on remote GCS storage, after last update my code stopped working. So I think this changes can be useful not only for me :)

```
func processImage(processor *picfit.Processor, qs map[string]interface{}, storeKey string, async bool) (*image.ImageFile, error) {

    file := &image.ImageFile{
        Key:     storeKey,
        Storage: processor.DestinationStorage,
        Headers: map[string]string{},
    }

    var filepath string

    var err error

    // URL provided we use http protocol to retrieve it
    filepath = qs["path"].(string)
    if !processor.SourceStorage.Exists(filepath) {
        return nil, failure.ErrFileNotExists
    }

    file, err = image.FromStorage(processor.SourceStorage, filepath)
    if err != nil {
        return nil, err
    }

    parameters, err := processor.NewParameters(file, qs)
    if err != nil {
        return nil, err
    }

    file, err = processor.Engine.Transform(parameters.Output, parameters.Operations)
    if err != nil {
        return nil, err
    }
```