### PR TITLE
Add working dockerfile, add documentation for config file location

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+Dockerfile.*
+LICENSE
+.travis.yml
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM alpine:3.7
+FROM golang:1.14-buster as builder
+LABEL stage=builder
 
-RUN apk add --no-cache ca-certificates
+ENV REPO=thoas/picfit
 
-ADD bin/picfit /picfit
+ADD . /go/src/github.com/${REPO}
+
+WORKDIR /go/src/github.com/${REPO}
+
+RUN make docker-build-static && mv bin/picfit /picfit
+
+###
+
+FROM debian:buster-slim
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+COPY --from=builder /picfit /picfit
 
 CMD ["/picfit"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch
+FROM golang:1.13-buster
 
 ADD . /go/src/github.com/thoas/picfit
 

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,8 @@ Configuration
 
 Configuration should be stored in a readable file and in JSON format.
 
+The location of the configuration is specified by --config or the PICFIT_CONFIG_PATH environment variable.
+
 ``config.json``
 
 .. code-block:: json


### PR DESCRIPTION
(Closes #127)

The `alpine` based-docker image does not work with the latest version of picfit because it's missing glibc, and we can't compile with `CGO_ENABLED=0` because [lilliput](https://github.com/discordapp/lilliput) doesn't support it.

This pull request switches the image to the glibc-based `debian:buster-slim`, as well as adding a multi-stage build in the base Dockerfile to ensure all OS dependencies match, and adding a .dockerignore file to speed up builds with layer caching. It also documents the environment variable `PICFIT_CONFIG_PATH` which is useful for Docker builds.