### PR TITLE
if storage file purged reprocess image vs returning error

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"strings"
 
 	conv "github.com/cstockton/go-conv"
@@ -243,7 +244,12 @@ func (p *Processor) ProcessContext(c *gin.Context, opts ...Option) (*image.Image
 				logger.String("key", storeKey),
 				logger.String("filepath", filepath))
 
-			return p.fileFromStorage(storeKey, filepath, options.Load)
+			img, err := p.fileFromStorage(storeKey, filepath, options.Load)
+			//no such file, just reprocess (maybe file cache was purged)
+			if err != nil && os.IsNotExist(err) {
+				return p.processImage(c, storeKey, options.Async)
+			}
+			return img, err
 		}
 
 		// Image not found from the Store, we need to process it


### PR DESCRIPTION
We are using file system (fs) for STORAGE and in-memory cache for KVSTORE.  Over time many of the images in STORAGE are not used and could be purged to reduce our footprint. We typically will do that once a month.  Purging the STORAGE causes any of those images still in the in-memory KVSTORE to fail to render since the file does not exist. If we restart Picfit it works fine since the in-memory cache is reset.  This looked like a more elegant solution to the problem since if its not found in the STORAGE just reprocess the image again.
