### PR TITLE
feat: dont detect mime type if key exist in URLParser middleware

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -218,7 +218,6 @@ func (p *Processor) ProcessContext(c *gin.Context, opts ...Option) (*image.Image
 		ctx      = c.Request.Context()
 		log      = p.Logger.With(logger.String("key", storeKey))
 	)
-
 	modifiedSince := c.Request.Header.Get("If-Modified-Since")
 	if modifiedSince != "" && force == "" {
 		exists, err := p.store.Exists(ctx, storeKey)

--- a/server/http.go
+++ b/server/http.go
@@ -137,7 +137,7 @@ func (s *HTTPServer) Init() error {
 			middleware.ParametersParser(),
 			middleware.KeyParser(),
 			middleware.Security(s.config.SecretKey),
-			middleware.URLParser(s.config.Options.MimetypeDetector),
+			middleware.URLParser(s.config.Options.MimetypeDetector, s.processor),
 			middleware.OperationParser(),
 			middleware.RestrictSizes(s.config.Options.AllowedSizes),
 			e.handler,


### PR DESCRIPTION
J'ai l'impression que si la clé existe on pas besoin de verifier le typ mime qui est assez couteux.