### PR TITLE
log: log unexpected error and ignore healthcheck

### DIFF
--- a/failure/http.go
+++ b/failure/http.go
@@ -30,6 +30,7 @@ func Handle(h Handler) gin.HandlerFunc {
 				c.String(http.StatusBadRequest, cerr.Error())
 			}
 
+			c.Error(err)
 			panic(err)
 		}
 	}

--- a/server/http.go
+++ b/server/http.go
@@ -70,13 +70,16 @@ func (s *HTTPServer) Init() error {
 		}
 	)
 
+	router.GET("/healthcheck", handlers.healthcheck(time.Now().UTC()))
+
+	router.Use(middleware.NewLogger(s.processor.Logger))
+
 	if s.config.Debug {
 		router.Use(gin.Recovery())
 	} else {
 		router.Use(middleware.Recover)
 	}
 
-	router.Use(middleware.NewLogger(s.processor.Logger))
 	router.Use(middleware.Metrics)
 
 	if s.config.Sentry != nil {
@@ -111,8 +114,6 @@ func (s *HTTPServer) Init() error {
 			AllowedHeaders:  s.config.AllowedHeaders,
 		}))
 	}
-
-	router.GET("/healthcheck", handlers.healthcheck(time.Now().UTC()))
 
 	restrictIPAddresses := middleware.RestrictIPAddresses(s.config.Options.AllowedIPAddresses)
 


### PR DESCRIPTION
- dont log request related to /healthcheck
- log error that we panic in failure.Handle, such as
```json
{"time":"2024-05-08T22:04:24.685983+08:00","level":"INFO","msg":"Key not found in store","key":"45859a0eb50d1633626b1063a2ef87a8","request-id":"2b099bc3-7c06-41a9-ac07-184626fc5fbd"}
{"time":"2024-05-08T22:04:26.343446+08:00","level":"INFO","msg":"Force free memory","alloc":"4 MiB","heap-alloc":"4 MiB","total-alloc":"6 MiB","sys":"15 MiB","numgc":2,"total-goroutine":11}
{"time":"2024-05-08T22:04:36.342366+08:00","level":"INFO","msg":"Force free memory","alloc":"4 MiB","heap-alloc":"4 MiB","total-alloc":"7 MiB","sys":"15 MiB","numgc":3,"total-goroutine":11}
{"time":"2024-05-08T22:04:45.236336+08:00","level":"INFO","msg":"Retrieved image to process from storage","key":"45859a0eb50d1633626b1063a2ef87a8","image":"/companion/npcs/static/banner/496ec823-32aa-4619-b89e-23462f6b1417/pic","size":"283.7 kB","duration":20549878166,"request-id":"2b099bc3-7c06-41a9-ac07-184626fc5fbd"}
{"time":"2024-05-08T22:04:45.236558+08:00","level":"INFO","msg":"Processing image","logger":"engine","backend":"goimage","operation":"noop","options":"width:0 height:0 quality:95 upscale:true","duration":"17.834µs","request-id":"2b099bc3-7c06-41a9-ac07-184626fc5fbd"}
{"time":"2024-05-08T22:04:45.236642+08:00","level":"INFO","msg":"Image processed","key":"45859a0eb50d1633626b1063a2ef87a8","image":"/companion/npcs/static/banner/496ec823-32aa-4619-b89e-23462f6b1417/pic","size":"283.7 kB","image":"45859a0eb50d1633626b1063a2ef87a8.png","size":"283.7 kB","duration":99875,"request-id":"2b099bc3-7c06-41a9-ac07-184626fc5fbd"}
{"time":"2024-05-08T22:04:46.343105+08:00","level":"INFO","msg":"Force free memory","alloc":"4 MiB","heap-alloc":"4 MiB","total-alloc":"8 MiB","sys":"19 MiB","numgc":4,"total-goroutine":13}
{"time":"2024-05-08T22:04:47.852245+08:00","level":"ERROR","msg":"unable to store processed image: /companion/npcs/static/banner/496ec823-32aa-4619-b89e-23462f6b1417/pic: AccessControlListNotSupported: The bucket does not allow ACLs\n\tstatus code: 400, request id: X1CX5CDXQMYAC887, host id: ELvRhzXq4V7ZMdihJJ32uLOoHHeJWAhx4bOiBpZqW92XhmqfEwl9odJfIl9R35VF9oZFHA4oD/E=","status":500,"method":"GET","params":{"op":["noop"],"path":["/companion/npcs/static/banner/496ec823-32aa-4619-b89e-23462f6b1417/pic"]},"path":"/get","ip":"[127.0.0.1](http://127.0.0.1/)","duration":23166420083,"user-agent":"curl/8.4.0","request-id":"2b099bc3-7c06-41a9-ac07-184626fc5fbd"}
```