### PR TITLE
fix simplest config in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ a request only once.
       },
       "kvstore": {
         "type": "cache"
-      },
+      }
     }
 
 Store images on DigitalOcean S3


### PR DESCRIPTION
Thanks for the lib

Quite a strict JSON parser used for parsing the config, not allowing trailing commas, it was giving me the error
`While parsing config: invalid character '}' looking for beginning of object key string%  `
